### PR TITLE
compile boost with llvm-toolset

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,7 @@ DTSVER: 7
 GCC_DIST: gcc
 
 cplusplus_devtoolset: "devtoolset-{{ DTSVER }}"
+llvm_toolset: 'llvm-toolset-7.0'
 
 # boost_prefix used for zlib and bzip2 too
 boost_prefix: /usr/local

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,11 +34,29 @@
   set_fact:
     cmd_env: "source /opt/rh/{{ cplusplus_devtoolset }}/enable && "
 
+- name: source llvm toolset enable file
+  when:
+    - collections_enabled
+    - ansible_os_family == 'RedHat'
+    - GCC_DIST == 'clang'
+  set_fact:
+    cmd_env: "source /opt/rh/{{ llvm_toolset }}/enable && "
+
 - name: what is my gcc compiler?
   environment:
     PATH: '/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/bin:/usr/bin'
   shell: "{{ cmd_env | default('') }} gcc -v"
   register: gcc_version
+  changed_when: false
+  tags:
+    - skip_ansible_lint
+
+- name: what is my clang compiler?
+  when: GCC_DIST == 'clang'
+  environment:
+    PATH: '/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/bin:/usr/bin'
+  shell: "{{ cmd_env | default('') }} clang -v"
+  register: clang_version
   changed_when: false
   tags:
     - skip_ansible_lint
@@ -121,7 +139,7 @@
     return_content: true
   register: boost
   until: boost is success
-  retries: 3600
+  retries: 3
   delay: 5
   tags:
     - base_boost
@@ -190,11 +208,19 @@
     - base_boost
     - boost
 
+- name: set toolset
+  set_fact:
+    toolset: "{{ GCC_DIST|default('gcc') }}"
+
+- name: display toolset
+  debug:
+    msg: "toolset (gcc or clang): {{ toolset }}"
+
 - name: bootstrap Boost libraries
   when: boost.status == 200
   environment:
     PATH: '/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/bin:/usr/bin'
-  shell: "{{ cmd_env | default('') }} ./bootstrap.sh --with-toolset={{ GCC_DIST|default('gcc') }} --without-libraries=python --without-icu --prefix={{ boost_prefix }}"
+  shell: "{{ cmd_env | default('') }} ./bootstrap.sh --with-toolset={{ toolset }} --without-libraries=python --without-icu --prefix={{ boost_prefix }}"
   args:
     chdir: "{{ boost_workdir }}/{{ boost_dest }}"
     creates: "{{ boost_workdir }}/{{ boost_dest }}/project-config.jam"
@@ -231,7 +257,7 @@
   environment:
     PATH: '/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/bin:/usr/bin'
   shell: "{{ cmd_env | default('') }} ./b2 -j{{ ansible_processor_vcpus }} \
-     toolset={{ GCC_DIST|default('gcc') }}
+     toolset=gcc
      {{ boost_properties }} variant={{ boost_variant }} cflags=-fPIC cxxflags=-fPIC \
      -sZLIB_SOURCE={{ boost_workdir }}/zlib-{{ zlib_version }} \
      -sBZIP2_SOURCE={{ boost_workdir }}/bzip2-{{ bzip2_version }} \
@@ -239,7 +265,33 @@
   args:
     chdir: "{{ boost_workdir }}/{{ boost_dest }}"
     creates: "{{ boost_workdir }}/{{ boost_dest }}/stage/lib/libboost_regex.a"
-  when: compile_boost is defined and compile_boost and boost.status == 200
+  when:
+    - compile_boost is defined
+    - compile_boost|bool
+    - toolset == 'gcc'
+    - boost.status == 200
+  tags:
+    - base_boost
+    - boost
+    - skip_ansible_lint
+
+- name: compile Boost libraries
+  environment:
+    PATH: '/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/bin:/usr/bin'
+  shell: "{{ cmd_env | default('') }} ./b2 -j{{ ansible_processor_vcpus }} \
+     toolset=clang
+     {{ boost_properties }} variant={{ boost_variant }} cflags=-fPIC cxxflags=-fPIC \
+     -sZLIB_SOURCE={{ boost_workdir }}/zlib-{{ zlib_version }} \
+     -sBZIP2_SOURCE={{ boost_workdir }}/bzip2-{{ bzip2_version }} \
+     {{ compile_boost_with }}"
+  args:
+    chdir: "{{ boost_workdir }}/{{ boost_dest }}"
+    creates: "{{ boost_workdir }}/{{ boost_dest }}/stage/lib/libboost_regex.a"
+  when:
+    - compile_boost is defined
+    - compile_boost|bool
+    - toolset == 'clang'
+    - boost.status == 200
   tags:
     - base_boost
     - boost


### PR DESCRIPTION
Let's compile Boost with the llvm-toolset first. Compiling LLVM+CLang takes almost 3 hours.