### PR TITLE
We don't keep the source for boost. So the goss test should be amended.

### DIFF
--- a/templates/test_boost.yml.j2
+++ b/templates/test_boost.yml.j2
@@ -4,10 +4,4 @@ file:
     exists: true
   {{ boost_prefix }}/lib/libboost_bzip2.a:
     exists: true
-  {{ boost_workdir }}/boost_{{ boost_version | replace('.','_') }}:
-    exists: true
-    filetype: directory
-  {{ boost_workdir }}/boost_{{ boost_version | replace('.','_') }}/b2:
-    exists: true
-    filetype: file
 {% endif %}


### PR DESCRIPTION
there is no directory under /usr/local/src/... that was removed in 1.0.5