### PR TITLE
adding exception for ansible-lint

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -296,6 +296,7 @@
 - name: install Boost libraries
   environment:
     PATH: '/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/bin:/usr/bin'
+  # yamllint disable-line rule:line-length
   shell: "{{ cmd_env | default('') }} ./b2 -j{{ ansible_processor_vcpus }} {{ boost_properties }} variant={{ boost_variant }} cflags='{{ boost_cflags }}' cxxflags='{{ boost_cxxflags }}' \
      -sZLIB_SOURCE={{ boost_workdir }}/zlib-{{ zlib_version }} \
      -sBZIP2_SOURCE={{ boost_workdir }}/bzip2-{{ bzip2_version }} \

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -191,7 +191,7 @@
   get_url:
     url: "{{ boost_url }}"
     dest: "/tmp/{{ boost_file }}"
-    sha256sum: "{{ sha256sum }}"
+    checksum: "sha256:{{ sha256sum }}"
     mode: 0755
   register: download_boost
   until: download_boost is succeeded


### PR DESCRIPTION
```
[204] Lines should be no longer than 160 chars
roles/dockpack.base_boost/tasks/main.yml:299
  shell: "{{ cmd_env | default('') }} ./b2 -j{{ ansible_processor_vcpus }} {{ boost_properties }} variant={{ boost_variant }} cflags='{{ boost_cflags }}' cxxflags='{{ boost_cxxflags }}' \
```