### PR TITLE
no dots in role names.

### DIFF
--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: https://github.com/dockpack/base_gcc.git
-  name: dockpack.base_gcc
+  name: ase_gcc

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,3 @@
 ---
 - src: https://github.com/dockpack/base_gcc.git
-  name: ase_gcc
+  name: base_gcc


### PR DESCRIPTION
Centos 8 compiles Boost now, Centos 7 with DTS tested